### PR TITLE
align numeric columns and handle sort icon in the alignment

### DIFF
--- a/app/components/table/EnhancedTableHead.tsx
+++ b/app/components/table/EnhancedTableHead.tsx
@@ -75,12 +75,26 @@ function EnhancedTableHead(props: EnhancedTableProps) {
               direction={orderBy === headCell.id ? order : 'asc'}
               onClick={createSortHandler(headCell.id)}
             >
-              {headCell.label}
-              {orderBy === headCell.id ? (
-                <Box component='span' sx={visuallyHidden}>
-                  {order === 'desc' ? 'sorted descending' : 'sorted ascending'}
-                </Box>
-              ) : null}
+              {/* Sort icon makes alignment look off so we put it to the opposite side */}
+              {headCell.numeric ? (
+                <>
+                  {headCell.label}
+                  {orderBy === headCell.id ? (
+                    <Box component='span' sx={visuallyHidden}>
+                      {order === 'desc' ? 'sorted descending' : 'sorted ascending'}
+                    </Box>
+                  ) : null}
+                </>
+              ) : (
+                <>
+                  {orderBy === headCell.id ? (
+                    <Box component='span' sx={visuallyHidden}>
+                      {order === 'desc' ? 'sorted descending' : 'sorted ascending'}
+                    </Box>
+                  ) : null}
+                  {headCell.label}
+                </>
+              )}
             </TableSortLabel>
           </TableCell>
         ))}

--- a/app/routes/providerData/annualProviderData.tsx
+++ b/app/routes/providerData/annualProviderData.tsx
@@ -161,7 +161,7 @@ const renderCellContent = (
         <TooltipTableCell
           key={key}
           tooltipTitle={row.overallRiskScore}
-          align='center'
+          align='right'
           sx={{
             color: getColor(row.overallRiskScore),
           }}
@@ -171,25 +171,25 @@ const renderCellContent = (
       );
     case 'childrenBilledOverCapacity':
       return (
-        <TooltipTableCell tooltipTitle={row.childrenBilledOverCapacity} key={key} align='center'>
+        <TooltipTableCell tooltipTitle={row.childrenBilledOverCapacity} key={key} align='right'>
           {row.childrenBilledOverCapacity}
         </TooltipTableCell>
       );
     case 'distanceTraveled':
       return (
-        <TooltipTableCell tooltipTitle={row.distanceTraveled} key={key} align='center'>
+        <TooltipTableCell tooltipTitle={row.distanceTraveled} key={key} align='right'>
           {row.distanceTraveled}
         </TooltipTableCell>
       );
     case 'childrenPlacedOverCapacity':
       return (
-        <TooltipTableCell tooltipTitle={row.childrenPlacedOverCapacity} key={key} align='center'>
+        <TooltipTableCell tooltipTitle={row.childrenPlacedOverCapacity} key={key} align='right'>
           {row.childrenPlacedOverCapacity}
         </TooltipTableCell>
       );
     case 'providersWithSameAddress':
       return (
-        <TooltipTableCell tooltipTitle={row.providersWithSameAddress} key={key} align='center'>
+        <TooltipTableCell tooltipTitle={row.providersWithSameAddress} key={key} align='right'>
           {row.providersWithSameAddress}
         </TooltipTableCell>
       );
@@ -276,17 +276,19 @@ export default function AnnualProviderData() {
   }, [error]);
 
   const visibleRows = useMemo<AnnualData[]>(() => {
-    const items = !error
-      ? rows?.pages?.flat().filter(dataRow => {
-          const providerName = dataRow?.providerName.toLocaleLowerCase() || '';
-          const providerId = dataRow?.providerLicensingId.toLocaleLowerCase() || '';
-          const searchTerm = searchValue?.toLocaleLowerCase() || '';
-          if (providerName?.includes(searchTerm) || providerId?.includes(searchTerm)) {
-            return true;
-          }
+    const items =
+      rows?.pages?.flat().filter(dataRow => {
+        if (dataRow?.error) {
           return false;
-        }) || []
-      : [];
+        }
+        const providerName = dataRow?.providerName.toLocaleLowerCase() || '';
+        const providerId = dataRow?.providerLicensingId.toLocaleLowerCase() || '';
+        const searchTerm = searchValue?.toLocaleLowerCase() || '';
+        if (providerName?.includes(searchTerm) || providerId?.includes(searchTerm)) {
+          return true;
+        }
+        return false;
+      }) || [];
 
     setLocalFlags(() =>
       items.reduce((acc, curr) => {

--- a/app/routes/providerData/monthlyProviderData.tsx
+++ b/app/routes/providerData/monthlyProviderData.tsx
@@ -150,7 +150,7 @@ const renderCellContent = (
         <TooltipTableCell
           key={key}
           tooltipTitle={row.overallRiskScore}
-          align='center'
+          align='right'
           sx={{
             color: getColor(row.overallRiskScore),
           }}
@@ -160,25 +160,25 @@ const renderCellContent = (
       );
     case 'childrenBilledOverCapacity':
       return (
-        <TooltipTableCell tooltipTitle={row.childrenBilledOverCapacity} key={key} align='center'>
+        <TooltipTableCell tooltipTitle={row.childrenBilledOverCapacity} key={key} align='right'>
           {row.childrenBilledOverCapacity}
         </TooltipTableCell>
       );
     case 'distanceTraveled':
       return (
-        <TooltipTableCell tooltipTitle={row.distanceTraveled} key={key} align='center'>
+        <TooltipTableCell tooltipTitle={row.distanceTraveled} key={key} align='right'>
           {row.distanceTraveled}
         </TooltipTableCell>
       );
     case 'childrenPlacedOverCapacity':
       return (
-        <TooltipTableCell tooltipTitle={row.childrenPlacedOverCapacity} key={key} align='center'>
+        <TooltipTableCell tooltipTitle={row.childrenPlacedOverCapacity} key={key} align='right'>
           {row.childrenPlacedOverCapacity}
         </TooltipTableCell>
       );
     case 'providersWithSameAddress':
       return (
-        <TooltipTableCell tooltipTitle={row.providersWithSameAddress} key={key} align='center'>
+        <TooltipTableCell tooltipTitle={row.providersWithSameAddress} key={key} align='right'>
           {row.providersWithSameAddress}
         </TooltipTableCell>
       );

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -21,13 +21,14 @@ export interface Data {
 }
 
 export interface AnnualData extends Data {
+  error?: string;
   postalAddress: string;
   city: string;
   zip: string;
 }
 
-
 export interface MonthlyData extends Data {
+  error?: string;
   startOfMonth?: string;
   postalAddress: string;
   city: string;


### PR DESCRIPTION
Should Address:


Sr No | Priority | Status | Description
-- | -- | -- | --
1 | High |   | Column header allignment with column values - could we make all column values left alligned with column header?
  |   |   |  
2 | High |   | There are a bunch of providers who scored 48 on the annual view, i.e. they were flagged on all 4 categories for past 12 months. But lot of them don't appear in the monthly view. One example is "KnowledgePoints Learning Academy". I checked the backend, "KnowledgePoints Learning Academy" was flagged for all 12 months in 2024 in the backend table too (see screenshot). So it should appear on the monthly view on the front end.
  |   |   |  
3 | Medium |   | Can't flag providers on annual view
  |   |   |  
4 | Medium |   | "Flagged" filter on monthly view showing incorrect results
